### PR TITLE
feat: support dynamic DSNs

### DIFF
--- a/ftl_auth_proxy.go
+++ b/ftl_auth_proxy.go
@@ -12,12 +12,12 @@ import (
 type Proxy struct {
 	host        string
 	port        int
-	dsn         string
+	dsn         func(context.Context) (string, error)
 	logger      Logger
 	portBinding chan int
 }
 
-func NewProxy(host string, port int, dsn string, logger Logger, portBinding chan int) *Proxy {
+func NewProxy(host string, port int, dsn func(context.Context) (string, error), logger Logger, portBinding chan int) *Proxy {
 	if logger == nil {
 		logger = defaultLogger
 	}
@@ -40,7 +40,11 @@ func (p *Proxy) ListenAndServe(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	cfg, err := ParseDSN(p.dsn)
+	dsn, err := p.dsn(ctx)
+	if err != nil {
+		return err
+	}
+	cfg, err := ParseDSN(dsn)
 	if err != nil {
 		return err
 	}

--- a/ftl_auth_proxy_test.go
+++ b/ftl_auth_proxy_test.go
@@ -13,7 +13,10 @@ import (
 
 func TestMysqlAuthProxy(t *testing.T) {
 	portC := make(chan int)
-	proxy := NewProxy("localhost", 0, "admin:admin@tcp(127.0.0.1:3306)/mydatabase", defaultLogger, portC)
+	dsnFunc := func(ctx context.Context) (string, error) {
+		return "admin:admin@tcp(127.0.0.1:3306)/mydatabase", nil
+	}
+	proxy := NewProxy("localhost", 0, dsnFunc, defaultLogger, portC)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	go func() {


### PR DESCRIPTION
This allows us to return a different DSN for every connection request, in case we are using short lived tokens to establish connections